### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "OSL-3.0"
     ],
     "require": {
-        "magento/framework": "^100.0|^101.0|^102.0"
+        "magento/framework": "*"
     },
     "type": "magento2-language",
     "autoload": {


### PR DESCRIPTION
It would good idea to allow to install all the version of magento2. 
`"magento/framework": "^100.0|^101.0|^102.0"`
does not allow to install in `2.4` in future, it might change to `2.5`. But it is just language package. So in my opinion It should be allowed to install in all version. 

Thanks 
